### PR TITLE
Release v0.4.0.pre

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+### v0.4.0.pre
+
+* bug-fixes
+  * Fix product attribute definition `create` method
+  * Fix product attribute definition `delete` method
+  * Fix product custom attribute module name
+  * Include `BeyondApi::ProductCustomAttributes` module into `BeyondApi::Products` class
+  * Include `BeyondApi::ProductImages` module into `BeyondApi::Products` class
+
+* enhancements
+  * Allow to get all product attribute definitions on a single call
+
 ### v0.3.0.pre
 
 * bug-fixes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    beyond_api (0.3.0.pre)
+    beyond_api (0.4.0.pre)
       faraday (~> 0.15)
 
 GEM

--- a/lib/beyond_api/resources/product_attribute_definitions.rb
+++ b/lib/beyond_api/resources/product_attribute_definitions.rb
@@ -56,8 +56,8 @@ module BeyondApi
     #   }
     #   @product_attribute_definition = session.product_attribute_definitions.create(body)
     #
-    def create(product_attribute_name)
-      response, status = BeyondApi::Request.post(@session, "/product-attribute-definitions")
+    def create(body)
+      response, status = BeyondApi::Request.post(@session, "/product-attribute-definitions", body)
 
       handle_response(response, status)
     end
@@ -80,7 +80,7 @@ module BeyondApi
     #   session.product_attribute_definitions.delete("filling_capacity")
     #
     def delete(product_attribute_name)
-      response, status = BeyondApi::Request.get(@session, "/product-attribute-definitions/#{product_attribute_name}")
+      response, status = BeyondApi::Request.delete(@session, "/product-attribute-definitions/#{product_attribute_name}")
 
       handle_response(response, status, respond_with_true: true)
     end

--- a/lib/beyond_api/resources/product_attribute_definitions.rb
+++ b/lib/beyond_api/resources/product_attribute_definitions.rb
@@ -28,7 +28,7 @@ module BeyondApi
         result = all_paginated(page: 0, size: 1000)
 
         (1..result[:page][:total_pages] - 1).each do |page|
-          result[:embedded][:product_attribute_definition].concat all_paginated(page: page, size: 1000)[:embedded][:product_attribute_definitions]
+          result[:embedded][:product_attribute_definition].concat(all_paginated(page: page, size: 1000)[:embedded][:product_attribute_definitions])
         end
 
         result.is_a?(Hash) ? result.delete(:page) : result.delete_field(:page)

--- a/lib/beyond_api/resources/product_attribute_definitions.rb
+++ b/lib/beyond_api/resources/product_attribute_definitions.rb
@@ -25,13 +25,13 @@ module BeyondApi
     #
     def all(params = {})
       if params[:paginated] == false
-        result = all_paginated(page: 0)
+        result = all_paginated(page: 0, size: 1000)
 
-        (1..result.page.total_pages - 1).each do |page|
-          result.embedded.product_attribute_definitions.concat all_paginated(page: page).embedded.product_attribute_definitions
+        (1..result[:page][:total_pages] - 1).each do |page|
+          result[:embedded][:product_attribute_definition].concat all_paginated(page: page, size: 1000)[:embedded][:product_attribute_definitions]
         end
 
-        result.delete_field(:page)
+        result.is_a?(Hash) ? result.delete(:page) : result.delete_field(:page)
         result
       else
         all_paginated(params)

--- a/lib/beyond_api/resources/products.rb
+++ b/lib/beyond_api/resources/products.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 require "beyond_api/utils"
+require "beyond_api/resources/products/custom_attributes"
 
 module BeyondApi
   class Products < Base
+    include BeyondApi::ProductCustomAttribute
     include BeyondApi::Utils
 
     #

--- a/lib/beyond_api/resources/products.rb
+++ b/lib/beyond_api/resources/products.rb
@@ -2,10 +2,12 @@
 
 require "beyond_api/utils"
 require "beyond_api/resources/products/custom_attributes"
+require "beyond_api/resources/products/images"
 
 module BeyondApi
   class Products < Base
     include BeyondApi::ProductCustomAttribute
+    include BeyondApi::ProductImages
     include BeyondApi::Utils
 
     #

--- a/lib/beyond_api/resources/products.rb
+++ b/lib/beyond_api/resources/products.rb
@@ -6,7 +6,7 @@ require "beyond_api/resources/products/images"
 
 module BeyondApi
   class Products < Base
-    include BeyondApi::ProductCustomAttribute
+    include BeyondApi::ProductCustomAttributes
     include BeyondApi::ProductImages
     include BeyondApi::Utils
 

--- a/lib/beyond_api/resources/products/custom_attributes.rb
+++ b/lib/beyond_api/resources/products/custom_attributes.rb
@@ -3,7 +3,7 @@
 require "beyond_api/utils"
 
 module BeyondApi
-  module ProductCustomAttribute
+  module ProductCustomAttributes
 
     #
     # A +POST+ request is used to create a product attribute, which defines the value of a certain {product attribute definition}[http://docs.beyondshop.cloud/#resources-product-attribute-definitions] for a specific {product}[http://docs.beyondshop.cloud/#resources-products].

--- a/lib/beyond_api/version.rb
+++ b/lib/beyond_api/version.rb
@@ -1,3 +1,3 @@
 module BeyondApi
-  VERSION = "0.3.0.pre".freeze
+  VERSION = "0.4.0.pre".freeze
 end


### PR DESCRIPTION
* bug-fixes
  * Fix product attribute definition `create` method
  * Fix product attribute definition `delete` method
  * Fix product custom attribute module name
  * Include `BeyondApi::ProductCustomAttributes` module into `BeyondApi::Products` class
  * Include `BeyondApi::ProductImages` module into `BeyondApi::Products` class

* enhancements
  * Allow to get all product attribute definitions on a single call